### PR TITLE
Add summary report to 'gitrepo sync' command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,12 +28,12 @@ Commands:
 'gitrepo sync' example
 ----------------------
 
-gitrepo sync [-h] [-f] [-p PROJECT [PROJECT ...]] file
+**gitrepo sync [-h] [-f] [-p PROJECT [PROJECT ...]] [-t NUM_THREADS] file**
 
 Sync the projects.
 
 positional arguments:
-   file                - Path to mapping file in YAML format (see format bellow)
+   file                - Path to projects mapping file in YAML format (see format bellow)
 
 .. code-block:: yaml
 
@@ -45,17 +45,16 @@ positional arguments:
 
 optional arguments:
    -h, --help           Show help message and exit
-   -f, --force          Force push
-   -p, --project        Project to sync
+   -f, --force          Force update remote repository without any checks
+   -p, --project        Project(s) to sync
+   -t, --num-thread     Number of worker threads (1 by default)
 
 
 ToDo
 ----
 * add additional commands;
-* add ability allow to customise push user per each repo;
-* add multithreading;
 * add ability to customise connection parameters;
-* add unit tests;
+* add more unit tests;
 
 
 Contributors

--- a/gitrepo/app.py
+++ b/gitrepo/app.py
@@ -30,9 +30,24 @@ class Application(app.App):
     """
 
     def configure_logging(self):
+        # Redefine cliff's default logging message format by adding threadName
+        # tag to identify logs from multiple threads
+        self.CONSOLE_MESSAGE_FORMAT = ('[%(threadName)s] : '
+                                       '%(levelname)-8s '
+                                       '%(message)s')
+        self.LOG_FILE_MESSAGE_FORMAT = ('[%(threadName)s] '
+                                        '[%(asctime)s] '
+                                        '%(levelname)-8s '
+                                        '%(name)s '
+                                        '%(message)s')
         super(Application, self).configure_logging()
 
-        git.cmd.Git.GIT_PYTHON_TRACE = True
+        # Enables debugging of GitPython's git commands
+        # depending on verbosity level
+        git.cmd.Git.GIT_PYTHON_TRACE = {0: False,  # '-q'
+                                        1: True,   # default level
+                                        2: 'full'  # '-v'
+                                        }.get(self.options.verbose_level, True)
 
 
 def main(argv=None):

--- a/gitrepo/commands/sync.py
+++ b/gitrepo/commands/sync.py
@@ -46,6 +46,10 @@ class GitSyncCommand(base.BaseCommand):
         parser.add_argument("-p", "--project",
                             nargs='+',
                             help="Project(s) to sync.")
+        parser.add_argument("-t", "--num-threads",
+                            type=int,
+                            default=1,
+                            help="Number of threads.")
         return parser
 
     def take_action(self, parsed_args):
@@ -53,7 +57,10 @@ class GitSyncCommand(base.BaseCommand):
             schemas.PROJECTS_SCHEMA,
             parsed_args.path
         )
-        self.client.sync(data, parsed_args.project, parsed_args.force)
+        self.client.sync(data,
+                         parsed_args.project,
+                         parsed_args.force,
+                         parsed_args.num_threads)
         self.app.stdout.write("====================\nCompleted...\n")
 
 

--- a/gitrepo/objects/sync.py
+++ b/gitrepo/objects/sync.py
@@ -45,7 +45,17 @@ class RepoSync(RepoBase):
         self.repo.create_remote(dst_name, dst_url)
 
     def push_branch(self, branch, dst_name="dst", force=False):
-        """Push changes from source branch to target one."""
+        """Push changes from source branch to target one.
+
+        :param branch: branch for pushing
+        :type branch: str
+        :param dst_name: destination repo name
+        :type dst_name: str
+        :param force: Forces update remote repo without any checks
+        :type force: bool
+        :return: success result as a tuple (True/False, err_msg)
+        :rtype: tuple
+        """
 
         push_infos = self.repo.remote(dst_name).push(
             "refs/remotes/origin/" + branch +
@@ -58,9 +68,13 @@ class RepoSync(RepoBase):
         if push_infos:
             for push_info in push_infos:
                 if push_info.flags & push_info.ERROR:
-                    logging.error(
-                        "Push failed for project '{0}': {1}".format(
-                            self.repo_name, push_info.summary))
+                    err_msg = ("Push failed for project '{0}': "
+                               "{1}".format(self.repo_name, push_info.summary))
+                    logging.error(err_msg)
+                    return False, err_msg
         else:
-            logging.error("Push failed for project `{0}`".format(
-                self.repo_name))
+            err_msg = "Push failed for project `{0}`".format(self.repo_name)
+            logging.error(err_msg)
+            return False, err_msg
+        # if push was successful then error message is empty
+        return True, ''

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-minversion = 2.1
 skipsdist = True
 envlist = py35,py27,pep8
 


### PR DESCRIPTION
When the number of sync projects is rather huge it's
hard to analyze whole log output. So let's make output
result for 'gitrepo sync' command more user-friendly
by adding summary report, that contains:
total number of synced projects, successfully synced
and sync failed ones with detailed error description

Change-Id: Ic3b40b06739f16e568905f1456db01a4d412f6ce